### PR TITLE
z3: tests: Fix test_pb_ops_model for Z3 >= 4.8.3

### DIFF
--- a/z3/tests/lib.rs
+++ b/z3/tests/lib.rs
@@ -118,6 +118,5 @@ fn test_pb_ops_model() {
     let yv = model.eval(&y).unwrap().as_bool().unwrap();
     info!("x: {}", xv);
     info!("y: {}", yv);
-    assert!(xv > yv);
     assert!((xv && !yv) || (!xv && yv));
 }


### PR DESCRIPTION
Z3 4.8.1 returned `x=false, y=true`, whereas Z3 4.8.3 and 4.8.4 return `x=true, y=false`.
Both models are valid but the assertion `xv > yv` selects for only one of them.